### PR TITLE
Fix generate in Quiz and base for logic manager

### DIFF
--- a/src/main/java/braintrain/logic/commands/StartCommand.java
+++ b/src/main/java/braintrain/logic/commands/StartCommand.java
@@ -19,9 +19,9 @@ public class StartCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Starting new quiz";
     public static final String MESSAGE_QUESTION_ANSWER = "Question: %1$s\nAnswer: %2$s";
 
-    public StartCommand() {
-        // TODO start session
-    }
+    //    public StartCommand() {
+    //        // TODO start session
+    //    }
 
     /**
      * Executes the command.

--- a/src/main/java/braintrain/logic/commands/StartCommand.java
+++ b/src/main/java/braintrain/logic/commands/StartCommand.java
@@ -1,0 +1,49 @@
+package braintrain.logic.commands;
+
+import java.util.Arrays;
+
+import braintrain.logic.CommandHistory;
+import braintrain.logic.commands.exceptions.CommandException;
+import braintrain.model.Model;
+import braintrain.quiz.Quiz;
+import braintrain.quiz.QuizCard;
+import braintrain.quiz.QuizModel;
+
+/**
+ * TODO: implement the actual start command
+ */
+public class StartCommand extends Command {
+    public static final String COMMAND_WORD = "start";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Starts a new quiz.\n";
+    public static final String MESSAGE_SUCCESS = "Starting new quiz";
+    public static final String MESSAGE_QUESTION_ANSWER = "Question: %1$s\nAnswer: %2$s";
+
+    public StartCommand() {
+        // TODO start session
+    }
+
+    /**
+     * Executes the command.
+     * TODO change this ugly method if possible.
+     */
+    public CommandResult executeActual(QuizModel model, CommandHistory history) {
+        // hardcoded values until session is ready
+        // only have question and answer
+        QuizCard card1 = new QuizCard("Japan", "Tokyo");
+        QuizCard card2 = new QuizCard("Hungary", "Budapest");
+        QuizCard card3 = new QuizCard("Christmas Island", "The Settlement");
+        QuizCard card4 = new QuizCard("中国", "北京");
+        Quiz quiz = new Quiz(Arrays.asList(card1, card2, card3, card4), Quiz.Mode.LEARN);
+
+        model.init(quiz);
+        QuizCard card = model.getNextCard();
+
+        return new CommandResult(String.format(MESSAGE_QUESTION_ANSWER, card.getQuestion(), card.getAnswer()));
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        return new CommandResult(String.format(MESSAGE_SUCCESS));
+    }
+}

--- a/src/main/java/braintrain/logic/delete_me.txt
+++ b/src/main/java/braintrain/logic/delete_me.txt
@@ -1,1 +1,0 @@
-git doesnt allow empty directories

--- a/src/main/java/braintrain/logic/parser/QuizModeParser.java
+++ b/src/main/java/braintrain/logic/parser/QuizModeParser.java
@@ -1,0 +1,65 @@
+package braintrain.logic.parser;
+
+import static braintrain.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static braintrain.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import braintrain.logic.commands.HelpCommand;
+import braintrain.logic.parser.exceptions.ParseException;
+import braintrain.quiz.commands.AnswerCommand;
+import braintrain.quiz.commands.QuizCommand;
+
+/**
+ * Parses user input in QuizMode
+ */
+public class QuizModeParser {
+
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\\\\\w*)|(?<answer>^\\S.+)");
+    private static Matcher matcher;
+
+    /**
+     * Checks if userInput is valid
+     * @param userInput
+     * @return
+     * @throws ParseException
+     */
+    public QuizCommand parse(String userInput) throws ParseException {
+        matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            // todo change to quiz help not mgmt help command
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+
+        final String commandWord = matcher.group("commandWord");
+        final String answer = matcher.group("answer");
+
+        if (commandWord != null) {
+            return parseCommand(commandWord);
+        } else {
+            return parseAnswer(answer);
+        }
+    }
+
+    private QuizCommand parseAnswer(String answer) {
+        return new AnswerCommand(answer);
+    }
+
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param command full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private QuizCommand parseCommand(String command) throws ParseException {
+        final String commandWord = matcher.group("commandWord");
+
+        switch (commandWord) {
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/braintrain/quiz/Quiz.java
+++ b/src/main/java/braintrain/quiz/Quiz.java
@@ -57,7 +57,6 @@ public class Quiz {
      * R
      */
     public List<QuizCard> generate() {
-        QuizCard currentCard;
         generatedSession = new ArrayList<>();
 
         switch (mode) {
@@ -67,7 +66,8 @@ public class Quiz {
         case LEARN:
             // Learn is a combination of Preview + Review
             generatePreview();
-            // Fall through
+            generateReview();
+            break;
         case REVIEW:
             generateReview();
             break;

--- a/src/main/java/braintrain/quiz/Quiz.java
+++ b/src/main/java/braintrain/quiz/Quiz.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents a quiz that stores a list of QuizCard
@@ -53,28 +54,57 @@ public class Quiz {
 
     /**
      * Generates a list of cards based on the chosen cards given by session.
+     * R
      */
     public List<QuizCard> generate() {
         QuizCard currentCard;
         generatedSession = new ArrayList<>();
 
-        if (mode != Mode.PREVIEW) {
-            for (int i = 0; i < currentSession.size(); i++) {
-                currentCard = currentSession.get(i);
-                generatedSession.add(new QuizCard(i, currentCard.getQuestion(), currentCard.getAnswer()));
-            }
-
-            for (int i = 0; i < currentSession.size(); i++) {
-                currentCard = currentSession.get(i);
-                generatedSession.add(new QuizCard(i, currentCard.getAnswer(), currentCard.getQuestion()));
-            }
-
-        } else {
-            generatedSession = currentSession;
+        switch (mode) {
+        case PREVIEW:
+            generatePreview();
+            break;
+        case LEARN:
+            // Learn is a combination of Preview + Review
+            generatePreview();
+            // Fall through
+        case REVIEW:
+            generateReview();
+            break;
+        default:
+            break;
         }
 
         generatedCardSize = generatedSession.size();
         return generatedSession;
+    }
+
+    /**
+     * Generates a list of card with the mode Review
+     */
+    private void generateReview() {
+        QuizCard currentCard;
+        for (int i = 0; i < currentSession.size(); i++) {
+            currentCard = currentSession.get(i);
+            generatedSession.add(new QuizCard(i, currentCard.getQuestion(), currentCard.getAnswer(), Mode.REVIEW));
+        }
+
+        for (int i = 0; i < currentSession.size(); i++) {
+            currentCard = currentSession.get(i);
+            generatedSession.add(new QuizCard(i, currentCard.getAnswer(), currentCard.getQuestion(), Mode.REVIEW));
+        }
+    }
+
+    /**
+     * Generates a list of card with the mode Preview see but don't need to answer.
+     */
+    private void generatePreview() {
+        QuizCard currentCard;
+
+        for (int i = 0; i < currentSession.size(); i++) {
+            currentCard = currentSession.get(i);
+            generatedSession.add(new QuizCard(i, currentCard.getQuestion(), currentCard.getAnswer(), Mode.PREVIEW));
+        }
     }
 
     /**
@@ -140,4 +170,28 @@ public class Quiz {
     public boolean isDone() {
         return isDone;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof Quiz)) {
+            return false;
+        }
+
+        // state check
+        Quiz other = (Quiz) obj;
+        return other.hashCode() == this.hashCode();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currentSession, generatedSession, mode,
+            currentQuizCard, currentCardIndex, isDone);
+    }
+
 }

--- a/src/main/java/braintrain/quiz/QuizCard.java
+++ b/src/main/java/braintrain/quiz/QuizCard.java
@@ -95,7 +95,7 @@ public class QuizCard {
      * @return the result after checking.
      */
     public boolean isCorrect(String answer) throws NullPointerException {
-        return answer.toLowerCase().equals(this.answer.toLowerCase());
+        return answer.equalsIgnoreCase(this.answer);
     }
 
     /**

--- a/src/main/java/braintrain/quiz/QuizCard.java
+++ b/src/main/java/braintrain/quiz/QuizCard.java
@@ -15,7 +15,7 @@ public class QuizCard {
 
     public static final String MESSAGE_CONSTRAINTS = "Question/answer can take any values, and it"
         + " should not be blank or contain only whitespaces";
-
+    private Quiz.Mode quizMode;
     private String question;
     private String answer;
     private List<String> opt;
@@ -46,13 +46,14 @@ public class QuizCard {
         this.streak = 0;
     }
 
-    public QuizCard(int index, String question, String answer) {
-        requireAllNonNull(index, question, answer);
+    public QuizCard(int index, String question, String answer, Quiz.Mode quizMode) {
+        requireAllNonNull(index, question, answer, quizMode);
         checkArgument(!question.trim().isEmpty() && !answer.isEmpty(), MESSAGE_CONSTRAINTS);
 
         this.index = index;
         this.question = question;
         this.answer = answer;
+        this.quizMode = quizMode;
     }
 
     public String getQuestion() {
@@ -68,7 +69,7 @@ public class QuizCard {
     }
 
     public int getIndex() throws NotInitialisedException {
-        if (index > 0) {
+        if (index > -1) {
             return index;
         }
 
@@ -83,13 +84,18 @@ public class QuizCard {
         return streak;
     }
 
+    public Quiz.Mode getQuizMode() {
+        requireAllNonNull(quizMode);
+        return quizMode;
+    }
+
     /**
      * Check if the given answer is the same as the answer of the card.
      * @param answer user's input answer.
      * @return the result after checking.
      */
     public boolean isCorrect(String answer) throws NullPointerException {
-        return answer.equals(this.answer);
+        return answer.toLowerCase().equals(this.answer.toLowerCase());
     }
 
     /**
@@ -97,13 +103,14 @@ public class QuizCard {
      * @param isCorrect the output of isCorrect method
      */
     public void updateTotalAttemptsAndStreak(boolean isCorrect) {
-        if (isCorrect) {
-            streak += 1;
-        } else {
-            streak = 0;
+        if (quizMode != Quiz.Mode.PREVIEW) {
+            if (isCorrect) {
+                streak += 1;
+            } else {
+                streak = 0;
+            }
+            totalAttempts += 1;
         }
-
-        totalAttempts += 1;
     }
 
     @Override

--- a/src/main/java/braintrain/quiz/QuizModelManager.java
+++ b/src/main/java/braintrain/quiz/QuizModelManager.java
@@ -67,4 +67,22 @@ public class QuizModelManager implements QuizModel {
     public List<List<Integer>> end() {
         return quiz.end();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof QuizModelManager)) {
+            return false;
+        }
+
+        // state check
+        QuizModelManager other = (QuizModelManager) obj;
+        return quiz.equals(other.quiz);
+    }
+
 }

--- a/src/main/java/braintrain/quiz/commands/AnswerCommand.java
+++ b/src/main/java/braintrain/quiz/commands/AnswerCommand.java
@@ -42,7 +42,14 @@ public class AnswerCommand extends QuizCommand {
                         card.getQuestion(), card.getAnswer()));
                 }
                 return new CommandResult(String.format(MESSAGE_QUESTION, card.getQuestion()));
+            } else {
+                sb.append(MESSAGE_COMPLETE);
+
+                // TODO return this to session
+                System.out.println(model.end());
             }
+
+            return new CommandResult(sb.toString());
         }
 
         try {

--- a/src/main/java/braintrain/quiz/commands/AnswerCommand.java
+++ b/src/main/java/braintrain/quiz/commands/AnswerCommand.java
@@ -1,0 +1,81 @@
+package braintrain.quiz.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import braintrain.logic.CommandHistory;
+import braintrain.logic.commands.CommandResult;
+import braintrain.logic.commands.exceptions.CommandException;
+import braintrain.quiz.Quiz;
+import braintrain.quiz.QuizCard;
+import braintrain.quiz.QuizModel;
+import braintrain.quiz.exceptions.NotInitialisedException;
+
+/**
+ * Execute User answer
+ */
+public class AnswerCommand extends QuizCommand {
+    public static final String MESSAGE_QUESTION = "Question: %1$s";
+    public static final String MESSAGE_QUESTION_ANSWER = "Question: %1$s\nAnswer: %2$s";
+    public static final String MESSAGE_CORRECT = "Your answer is correct.\n";
+    public static final String MESSAGE_WRONG = "The correct answer is %1$s.\n";
+    public static final String MESSAGE_COMPLETE = "You have completed all the questions in this quiz.\n";
+
+    private String answer;
+
+    public AnswerCommand(String answer) {
+        requireNonNull(answer);
+        this.answer = answer;
+    }
+
+    @Override
+    public CommandResult execute(QuizModel model, CommandHistory history) throws CommandException {
+        QuizCard card = model.getCurrentQuizCard();
+
+        StringBuilder sb = new StringBuilder();
+
+        if (card.getQuizMode() == Quiz.Mode.PREVIEW) {
+            // don't need to update totalAttempts and streak
+            if (model.hasCardLeft()) {
+                card = model.getNextCard();
+                if (card.getQuizMode() == Quiz.Mode.PREVIEW) {
+                    return new CommandResult(String.format(MESSAGE_QUESTION_ANSWER,
+                        card.getQuestion(), card.getAnswer()));
+                }
+                return new CommandResult(String.format(MESSAGE_QUESTION, card.getQuestion()));
+            }
+        }
+
+        try {
+            model.updateTotalAttemptsAndStreak(card.getIndex(), answer);
+        } catch (NotInitialisedException e) {
+            e.printStackTrace();
+        }
+
+        if (card.isCorrect(answer)) {
+            sb.append(MESSAGE_CORRECT);
+
+            if (model.hasCardLeft()) {
+                card = model.getNextCard();
+                sb.append(String.format(MESSAGE_QUESTION, card.getQuestion()));
+            } else {
+                sb.append(MESSAGE_COMPLETE);
+
+                // TODO return this to session
+                System.out.println(model.end());
+            }
+
+        } else {
+            sb.append(String.format(MESSAGE_WRONG, card.getAnswer()));
+            sb.append(String.format(MESSAGE_QUESTION, card.getQuestion()));
+        }
+
+        return new CommandResult(sb.toString());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof AnswerCommand // instanceof handles nulls
+            && answer.equals(((AnswerCommand) other).answer)); // state check
+    }
+}

--- a/src/main/java/braintrain/quiz/commands/QuizCommand.java
+++ b/src/main/java/braintrain/quiz/commands/QuizCommand.java
@@ -1,0 +1,22 @@
+package braintrain.quiz.commands;
+
+import braintrain.logic.CommandHistory;
+import braintrain.logic.commands.CommandResult;
+import braintrain.logic.commands.exceptions.CommandException;
+import braintrain.quiz.QuizModel;
+
+/**
+ * Represents a command with hidden internal logic and the ability to be executed.
+ */
+public abstract class QuizCommand {
+
+    /**
+     * Executes the command and returns the result message.
+     *
+     * @param model {@code QuizModel} which the command should operate on.
+     * @param history {@code CommandHistory} which the command should operate on.
+     * @return feedback message of the operation result for display
+     * @throws CommandException If an error occurs during command execution.
+     */
+    public abstract CommandResult execute(QuizModel model, CommandHistory history) throws CommandException;
+}

--- a/src/test/java/braintrain/logic/commands/StartCommandTest.java
+++ b/src/test/java/braintrain/logic/commands/StartCommandTest.java
@@ -1,0 +1,57 @@
+package braintrain.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import braintrain.logic.CommandHistory;
+import braintrain.model.Model;
+import braintrain.model.ModelManager;
+import braintrain.quiz.Quiz;
+import braintrain.quiz.QuizCard;
+import braintrain.quiz.QuizModel;
+import braintrain.quiz.QuizModelManager;
+
+public class StartCommandTest {
+
+    private static final CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_success() throws Exception {
+        Model model = new ModelManager();
+        CommandResult commandResult = new StartCommand().execute(model, commandHistory);
+
+        assertEquals(String.format(StartCommand.MESSAGE_SUCCESS), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void executeActual_success() {
+        // this hardcoded values matched StartCommand
+        // when session is implemented then this will change to session instead
+        final QuizCard card1 = new QuizCard("Japan", "Tokyo");
+        final QuizCard card2 = new QuizCard("Hungary", "Budapest");
+        final QuizCard card3 = new QuizCard("Christmas Island", "The Settlement");
+        final QuizCard card4 = new QuizCard("中国", "北京");
+        final List<QuizCard> quizCards = new ArrayList<>(Arrays.asList(card1, card2, card3, card4));
+        final Quiz quiz = new Quiz(quizCards, Quiz.Mode.LEARN);
+
+        QuizModelManager expectedModel = new QuizModelManager();
+        expectedModel.init(quiz);
+        expectedModel.getNextCard();
+        CommandResult expectedCommandResult = new StartCommand().executeActual(expectedModel, commandHistory);
+
+        QuizModel actualModel = new QuizModelManager();
+        StartCommand startCommand = new StartCommand();
+
+        CommandHistory expectedCommandHistory = new CommandHistory(commandHistory);
+        CommandResult result = startCommand.executeActual(actualModel, commandHistory);
+        assertEquals(expectedCommandResult, result);
+        assertEquals(expectedModel, actualModel);
+        assertEquals(expectedCommandHistory, commandHistory);
+    }
+
+}

--- a/src/test/java/braintrain/logic/parser/QuizModeParserTest.java
+++ b/src/test/java/braintrain/logic/parser/QuizModeParserTest.java
@@ -1,0 +1,50 @@
+package braintrain.logic.parser;
+
+import static braintrain.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static braintrain.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import braintrain.logic.commands.HelpCommand;
+import braintrain.logic.parser.exceptions.ParseException;
+import braintrain.quiz.commands.AnswerCommand;
+
+/**
+ * Parse user input in QuizMode
+ */
+public class QuizModeParserTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final QuizModeParser parser = new QuizModeParser();
+
+    @Test
+    public void parseAnswer() throws Exception {
+        assertTrue(parser.parse("some answer") instanceof AnswerCommand);
+        assertTrue(parser.parse("someanswer") instanceof AnswerCommand);
+    }
+
+    @Test
+    public void parse_unrecognisedInput_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        parser.parse("");
+    }
+
+    @Test
+    public void parse_onlyWhitespace_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        parser.parse("   ");
+    }
+
+    @Test
+    public void parse_unknownCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(MESSAGE_UNKNOWN_COMMAND);
+        parser.parse("\\unknownCommand");
+    }
+}

--- a/src/test/java/braintrain/quiz/QuizCardTest.java
+++ b/src/test/java/braintrain/quiz/QuizCardTest.java
@@ -17,13 +17,14 @@ public class QuizCardTest {
 
     private static final String QUESTION = "Japan";
     private static final String ANSWER = "Tokyo";
+    private static final Quiz.Mode MODE = Quiz.Mode.PREVIEW;
 
     private static final List<String> FIELDS_OPTIONALS = Arrays.asList("JP", "Asia");
     private static final List<String> FIELDS_OPTIONALS_EMPTY = Arrays.asList("", "");
 
     private static final QuizCard VALID_QUIZCARD_NO_OPT = new QuizCard(QUESTION, ANSWER);
     private static final QuizCard VALID_QUIZCARD = new QuizCard(QUESTION, ANSWER, FIELDS_OPTIONALS);
-    private static final QuizCard VALID_QUIZCARD_INDEX = new QuizCard(1, QUESTION, ANSWER);
+    private static final QuizCard VALID_QUIZCARD_INDEX = new QuizCard(1, QUESTION, ANSWER, Quiz.Mode.PREVIEW);
 
     @Test
     public void constructor_null_throwsNullPointerException() {
@@ -43,10 +44,10 @@ public class QuizCardTest {
             new QuizCard(QUESTION, ANSWER, null));
 
         Assert.assertThrows(NullPointerException.class, () ->
-            new QuizCard(0, null, null));
+            new QuizCard(0, null, null, MODE));
 
         Assert.assertThrows(NullPointerException.class, () ->
-            new QuizCard(0, QUESTION, null));
+            new QuizCard(0, QUESTION, null, MODE));
     }
 
     @Test
@@ -75,13 +76,13 @@ public class QuizCardTest {
             new QuizCard(QUESTION, invalidAns, FIELDS_OPTIONALS_EMPTY));
 
         Assert.assertThrows(IllegalArgumentException.class, () ->
-            new QuizCard(0, invalidQn, invalidAns));
+            new QuizCard(0, invalidQn, invalidAns, MODE));
 
         Assert.assertThrows(IllegalArgumentException.class, () ->
-            new QuizCard(1, "     ", ANSWER));
+            new QuizCard(1, "     ", ANSWER, MODE));
 
         Assert.assertThrows(IllegalArgumentException.class, () ->
-            new QuizCard(2, invalidQn, ANSWER));
+            new QuizCard(2, invalidQn, ANSWER, MODE));
 
     }
 
@@ -125,6 +126,17 @@ public class QuizCardTest {
     }
 
     @Test
+    public void getQuizMode_invalidQuizMode_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () ->
+            VALID_QUIZCARD.getQuizMode());
+    }
+
+    @Test
+    public void getQuizMode() {
+        assertEquals(MODE, VALID_QUIZCARD_INDEX.getQuizMode());
+    }
+
+    @Test
     public void isCorrect() {
         assertTrue(VALID_QUIZCARD.isCorrect(ANSWER));
 
@@ -138,7 +150,7 @@ public class QuizCardTest {
 
     @Test
     public void updateTotalAttemptsAndStreak() {
-        QuizCard quizCardWithIndex = VALID_QUIZCARD_INDEX;
+        QuizCard quizCardWithIndex = VALID_QUIZCARD;
 
         quizCardWithIndex.updateTotalAttemptsAndStreak(true);
         assertEquals(1, quizCardWithIndex.getTotalAttempts());
@@ -158,7 +170,7 @@ public class QuizCardTest {
     public void equals() {
         final QuizCard anotherValidQuizCard = new QuizCard(QUESTION, ANSWER);
         final QuizCard quizCardWithAb = new QuizCard("A", "B");
-        final QuizCard cardWithIndex = new QuizCard(0, QUESTION, ANSWER);
+        final QuizCard cardWithIndex = new QuizCard(0, QUESTION, ANSWER, MODE);
 
         // same object
         assertTrue(VALID_QUIZCARD.equals(VALID_QUIZCARD));
@@ -183,7 +195,7 @@ public class QuizCardTest {
     public void hashcode() {
         final QuizCard anotherValidQuizCard = new QuizCard(QUESTION, ANSWER);
         final QuizCard quizCardWithAb = new QuizCard("A", "B");
-        final QuizCard cardWithIndex = new QuizCard(0, QUESTION, ANSWER);
+        final QuizCard cardWithIndex = new QuizCard(0, QUESTION, ANSWER, MODE);
 
         // same value
         assertEquals(VALID_QUIZCARD_NO_OPT.hashCode(), anotherValidQuizCard.hashCode());

--- a/src/test/java/braintrain/quiz/QuizModelManagerTest.java
+++ b/src/test/java/braintrain/quiz/QuizModelManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.rules.ExpectedException;
 import braintrain.testutil.Assert;
 
 public class QuizModelManagerTest {
+    private static final Quiz.Mode MODE = Quiz.Mode.PREVIEW;
     private static final QuizCard QUIZCARD_1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
     private static final QuizCard QUIZCARD_2 = new QuizCard("Hungary", "Budapest");
     private static final List<QuizCard> VALID_QUIZCARD = Arrays.asList(QUIZCARD_1, QUIZCARD_2);
@@ -37,10 +38,13 @@ public class QuizModelManagerTest {
         modelManager.init(quiz);
 
         // get first card
-        assertEquals(new QuizCard(0, QUIZCARD_1.getQuestion(), QUIZCARD_1.getAnswer()), modelManager.getNextCard());
+        assertEquals(new QuizCard(0, QUIZCARD_1.getQuestion(), QUIZCARD_1.getAnswer(), MODE),
+            modelManager.getNextCard());
 
         // get the rest
         assertTrue(modelManager.hasCardLeft());
+        modelManager.getNextCard();
+        modelManager.getNextCard();
         modelManager.getNextCard();
         modelManager.getNextCard();
         modelManager.getNextCard();
@@ -58,7 +62,7 @@ public class QuizModelManagerTest {
         modelManager.init(new Quiz(quizCards, Quiz.Mode.LEARN));
         QuizCard expected = modelManager.getNextCard();
 
-        assertEquals(new QuizCard(0, "Japan", "Tokyo"), modelManager.getCurrentQuizCard());
+        assertEquals(new QuizCard(0, "Japan", "Tokyo", MODE), modelManager.getCurrentQuizCard());
         assertEquals(expected, modelManager.getCurrentQuizCard());
     }
 
@@ -92,6 +96,12 @@ public class QuizModelManagerTest {
 
         // after quiz end still can ask for next card, keeps track of previous entry
         assertTrue(modelManager.hasCardLeft());
+
+        // preview questions and answer
+        modelManager.getNextCard();
+        modelManager.getNextCard();
+
+        // start the actual quiz
         modelManager.getNextCard();
         modelManager.updateTotalAttemptsAndStreak(0, "Tokyo");
         modelManager.getNextCard();
@@ -106,5 +116,26 @@ public class QuizModelManagerTest {
         expected.add(Arrays.asList(1, 2, 2));
 
         assertEquals(expected, modelManager.end());
+    }
+
+    @Test
+    public void equals() {
+        Quiz quiz = new Quiz(VALID_QUIZCARD, Quiz.Mode.LEARN);
+
+        // same values -> returns true
+        modelManager = new QuizModelManager();
+        modelManager.init(quiz);
+        QuizModelManager modelManagerCopy = new QuizModelManager();
+        modelManagerCopy.init(quiz);
+        assertTrue(modelManager.equals(modelManagerCopy));
+
+        // same object -> returns true
+        assertTrue(modelManager.equals(modelManager));
+
+        // null -> returns false
+        assertFalse(modelManager == null);
+
+        // different types -> returns false
+        assertFalse(modelManager.equals(5));
     }
 }

--- a/src/test/java/braintrain/quiz/QuizTest.java
+++ b/src/test/java/braintrain/quiz/QuizTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import braintrain.testutil.Assert;
 
 public class QuizTest {
-    private static final Quiz.Mode MODE = Quiz.Mode.PREVIEW;
     private static final QuizCard QUIZCARD_1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
     private static final QuizCard QUIZCARD_2 = new QuizCard("Hungary", "Budapest");
     private static final List<QuizCard> VALID_QUIZCARD = Arrays.asList(QUIZCARD_1, QUIZCARD_2);

--- a/src/test/java/braintrain/quiz/QuizTest.java
+++ b/src/test/java/braintrain/quiz/QuizTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import braintrain.testutil.Assert;
 
 public class QuizTest {
+    private static final Quiz.Mode MODE = Quiz.Mode.PREVIEW;
     private static final QuizCard QUIZCARD_1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
     private static final QuizCard QUIZCARD_2 = new QuizCard("Hungary", "Budapest");
     private static final List<QuizCard> VALID_QUIZCARD = Arrays.asList(QUIZCARD_1, QUIZCARD_2);
@@ -33,31 +34,47 @@ public class QuizTest {
 
     @Test
     public void generate() {
-        // learn
-        List<QuizCard> expected = new ArrayList<>();
+        List<QuizCard> expectedPreview = new ArrayList<>();
+        List<QuizCard> expectedReview = new ArrayList<>();
+        List<QuizCard> expectedLearn = new ArrayList<>();
+
         QuizCard expectedCurrentCard;
         for (int i = 0; i < VALID_QUIZCARD.size(); i++) {
             expectedCurrentCard = VALID_QUIZCARD.get(i);
-            expected.add(new QuizCard(i, expectedCurrentCard.getQuestion(), expectedCurrentCard.getAnswer()));
+            expectedPreview.add(new QuizCard(i, expectedCurrentCard.getQuestion(), expectedCurrentCard.getAnswer(),
+                Quiz.Mode.PREVIEW));
         }
 
         for (int i = 0; i < VALID_QUIZCARD.size(); i++) {
             expectedCurrentCard = VALID_QUIZCARD.get(i);
-            expected.add(new QuizCard(i, expectedCurrentCard.getAnswer(), expectedCurrentCard.getQuestion()));
+            expectedReview.add(new QuizCard(i, expectedCurrentCard.getQuestion(), expectedCurrentCard.getAnswer(),
+                Quiz.Mode.REVIEW));
         }
 
+        for (int i = 0; i < VALID_QUIZCARD.size(); i++) {
+            expectedCurrentCard = VALID_QUIZCARD.get(i);
+            expectedReview.add(new QuizCard(i, expectedCurrentCard.getAnswer(), expectedCurrentCard.getQuestion(),
+                Quiz.Mode.REVIEW));
+        }
+
+        expectedLearn.addAll(expectedPreview);
+        expectedLearn.addAll(expectedReview);
+
+        // learn
         List<QuizCard> actualLearn = new Quiz(VALID_QUIZCARD, Quiz.Mode.LEARN).generate();
 
-        assertEquals(4, actualLearn.size());
-        assertEquals(expected, actualLearn);
+        assertEquals(6, actualLearn.size());
+        assertEquals(expectedLearn, actualLearn);
 
         // review
         List<QuizCard> actualReview = new Quiz(VALID_QUIZCARD, Quiz.Mode.REVIEW).generate();
         assertEquals(4, actualReview.size());
-        assertEquals(expected, actualReview);
+        assertEquals(expectedReview, actualReview);
 
         // preview
-        assertEquals(new Quiz(VALID_QUIZCARD, Quiz.Mode.PREVIEW).generate(), VALID_QUIZCARD);
+        List<QuizCard> actualPreview = new Quiz(VALID_QUIZCARD, Quiz.Mode.PREVIEW).generate();
+        assertEquals(2, actualPreview.size());
+        assertEquals(expectedPreview, actualPreview);
     }
 
     @Test
@@ -66,6 +83,8 @@ public class QuizTest {
         assertTrue(quiz.hasCardLeft());
 
         // get all cards
+        quiz.getNextCard();
+        quiz.getNextCard();
         quiz.getNextCard();
         quiz.getNextCard();
         quiz.getNextCard();
@@ -83,10 +102,9 @@ public class QuizTest {
 
         // normal
         List<QuizCard> generated = quiz.generate();
-        assertEquals(generated.get(0), quiz.getNextCard());
-        assertEquals(generated.get(1), quiz.getNextCard());
-        assertEquals(generated.get(2), quiz.getNextCard());
-        assertEquals(generated.get(3), quiz.getNextCard());
+        for (int i = 0; i < VALID_QUIZCARD.size() * 3; i++) {
+            assertEquals(generated.get(i), quiz.getNextCard());
+        }
 
         // no more cards
         Assert.assertThrows(IndexOutOfBoundsException.class, () ->
@@ -97,10 +115,9 @@ public class QuizTest {
 
         // normal
         List<QuizCard> generatedReview = quizReview.generate();
-        assertEquals(generatedReview.get(0), quizReview.getNextCard());
-        assertEquals(generatedReview.get(1), quizReview.getNextCard());
-        assertEquals(generatedReview.get(2), quizReview.getNextCard());
-        assertEquals(generatedReview.get(3), quizReview.getNextCard());
+        for (int i = 0; i < VALID_QUIZCARD.size() * 2; i++) {
+            assertEquals(generatedReview.get(i), quizReview.getNextCard());
+        }
 
         // no more cards
         Assert.assertThrows(IndexOutOfBoundsException.class, () ->
@@ -132,7 +149,7 @@ public class QuizTest {
         Quiz quiz = new Quiz(VALID_QUIZCARD, Quiz.Mode.LEARN);
         QuizCard expected = quiz.getNextCard();
 
-        assertEquals(new QuizCard(0, "Japan", "Tokyo"), quiz.getCurrentQuizCard());
+        assertEquals(new QuizCard(0, "Japan", "Tokyo", Quiz.Mode.PREVIEW), quiz.getCurrentQuizCard());
         assertEquals(expected, quiz.getCurrentQuizCard());
     }
 
@@ -198,6 +215,24 @@ public class QuizTest {
     }
 
     @Test
+    public void equals() {
+        Quiz quiz = new Quiz(VALID_QUIZCARD, Quiz.Mode.LEARN);
+
+        // same value -> returns true
+        Quiz quizCopy = new Quiz(VALID_QUIZCARD, Quiz.Mode.LEARN);
+        assertTrue(quiz.equals(quizCopy));
+
+        // same object -> returns true
+        assertTrue(quiz.equals(quiz));
+
+        // null -> returns false
+        assertFalse(quiz == null);
+
+        // different types -> returns false
+        assertFalse(quiz.equals(5));
+    }
+
+    @Test
     public void completeFlow() {
         List<List<Integer>> expected = new ArrayList<>();
         expected.add(Arrays.asList(0, 2, 2));
@@ -208,6 +243,10 @@ public class QuizTest {
         final List<QuizCard> quizCards = new ArrayList<>(Arrays.asList(card1, card2));
 
         Quiz quiz = new Quiz(quizCards, Quiz.Mode.LEARN);
+        // Preview questions and answers
+        quiz.getNextCard();
+        quiz.getNextCard();
+
         assertTrue(quiz.getNextCard().isCorrect("Tokyo"));
         quiz.updateTotalAttemptsAndStreak(0, "Tokyo");
 

--- a/src/test/java/braintrain/quiz/commands/AnswerCommandTest.java
+++ b/src/test/java/braintrain/quiz/commands/AnswerCommandTest.java
@@ -3,6 +3,7 @@ package braintrain.quiz.commands;
 import static braintrain.quiz.commands.AnswerCommand.MESSAGE_COMPLETE;
 import static braintrain.quiz.commands.AnswerCommand.MESSAGE_CORRECT;
 import static braintrain.quiz.commands.AnswerCommand.MESSAGE_QUESTION;
+import static braintrain.quiz.commands.AnswerCommand.MESSAGE_QUESTION_ANSWER;
 import static braintrain.quiz.commands.AnswerCommand.MESSAGE_WRONG;
 import static braintrain.quiz.commands.QuizCommandTestUtil.assertCommandSuccess;
 import static org.junit.Assert.assertFalse;
@@ -23,7 +24,6 @@ import braintrain.quiz.QuizModel;
 import braintrain.quiz.QuizModelManager;
 
 public class AnswerCommandTest {
-    private static final Quiz.Mode MODE = Quiz.Mode.PREVIEW;
     private static final QuizCard QUIZCARD_1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
     private static final QuizCard QUIZCARD_2 = new QuizCard("Hungary", "Budapest");
     private static final List<QuizCard> VALID_QUIZCARD = Arrays.asList(QUIZCARD_1, QUIZCARD_2);
@@ -33,7 +33,6 @@ public class AnswerCommandTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private CommandHistory commandHistory = new CommandHistory();
-    private QuizModel quizModel = new QuizModelManager();
 
     @Test
     public void constructor_nullAnswer_throwsNullPointerException() {
@@ -42,7 +41,7 @@ public class AnswerCommandTest {
     }
 
     @Test
-    public void execute_validPreview_success() {
+    public void execute_validLearn_success() {
         final String answer = "Tokyo";
         final QuizCard card1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
         final QuizCard card2 = new QuizCard("Hungary", "Budapest");
@@ -60,8 +59,41 @@ public class AnswerCommandTest {
         QuizCard card = expectedModel.getNextCard();
         card.isCorrect(answer);
 
-        String expectedMessage = String.format(AnswerCommand.MESSAGE_QUESTION_ANSWER, card.getQuestion(),
+        String expectedMessage = String.format(MESSAGE_QUESTION_ANSWER, card.getQuestion(),
             card.getAnswer());
+
+        assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validPreview_success() {
+        final String answer = "Tokyo";
+        final QuizCard card1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
+        final QuizCard card2 = new QuizCard("Hungary", "Budapest");
+        final List<QuizCard> quizCards = new ArrayList<>(Arrays.asList(card1, card2));
+        final Quiz quiz = new Quiz(quizCards, Quiz.Mode.PREVIEW);
+        QuizModelManager expectedModel = new QuizModelManager();
+        expectedModel.init(quiz);
+
+        QuizModel actual = new QuizModelManager();
+        actual.init(new Quiz(quizCards, Quiz.Mode.PREVIEW));
+        actual.getNextCard();
+
+        AnswerCommand answerCommand = new AnswerCommand(answer);
+        expectedModel.getNextCard();
+        QuizCard card = expectedModel.getNextCard();
+        card.isCorrect(answer);
+
+        String expectedMessage = String.format(MESSAGE_QUESTION_ANSWER, card.getQuestion(),
+            card.getAnswer());
+
+        assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
+
+        // complete preview quiz
+        answerCommand = new AnswerCommand("Budapest");
+        expectedModel.end();
+
+        expectedMessage = MESSAGE_COMPLETE;
 
         assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
     }
@@ -87,7 +119,7 @@ public class AnswerCommandTest {
         QuizCard card = expectedModel.getNextCard();
         card.isCorrect(answer);
 
-        String expectedMessage = String.format(AnswerCommand.MESSAGE_QUESTION, card.getQuestion());
+        String expectedMessage = String.format(MESSAGE_QUESTION, card.getQuestion());
 
         assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
     }

--- a/src/test/java/braintrain/quiz/commands/AnswerCommandTest.java
+++ b/src/test/java/braintrain/quiz/commands/AnswerCommandTest.java
@@ -151,7 +151,7 @@ public class AnswerCommandTest {
         card.isCorrect(correctAns);
 
         String expectedMessage = MESSAGE_CORRECT
-            + String.format(AnswerCommand.MESSAGE_QUESTION, card.getQuestion());
+            + String.format(MESSAGE_QUESTION, card.getQuestion());
 
         assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
 

--- a/src/test/java/braintrain/quiz/commands/AnswerCommandTest.java
+++ b/src/test/java/braintrain/quiz/commands/AnswerCommandTest.java
@@ -1,0 +1,171 @@
+package braintrain.quiz.commands;
+
+import static braintrain.quiz.commands.AnswerCommand.MESSAGE_COMPLETE;
+import static braintrain.quiz.commands.AnswerCommand.MESSAGE_CORRECT;
+import static braintrain.quiz.commands.AnswerCommand.MESSAGE_QUESTION;
+import static braintrain.quiz.commands.AnswerCommand.MESSAGE_WRONG;
+import static braintrain.quiz.commands.QuizCommandTestUtil.assertCommandSuccess;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import braintrain.logic.CommandHistory;
+import braintrain.quiz.Quiz;
+import braintrain.quiz.QuizCard;
+import braintrain.quiz.QuizModel;
+import braintrain.quiz.QuizModelManager;
+
+public class AnswerCommandTest {
+    private static final Quiz.Mode MODE = Quiz.Mode.PREVIEW;
+    private static final QuizCard QUIZCARD_1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
+    private static final QuizCard QUIZCARD_2 = new QuizCard("Hungary", "Budapest");
+    private static final List<QuizCard> VALID_QUIZCARD = Arrays.asList(QUIZCARD_1, QUIZCARD_2);
+    private static final Quiz QUIZ = new Quiz(VALID_QUIZCARD, Quiz.Mode.LEARN);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+    private QuizModel quizModel = new QuizModelManager();
+
+    @Test
+    public void constructor_nullAnswer_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new AnswerCommand(null);
+    }
+
+    @Test
+    public void execute_validPreview_success() {
+        final String answer = "Tokyo";
+        final QuizCard card1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
+        final QuizCard card2 = new QuizCard("Hungary", "Budapest");
+        final List<QuizCard> quizCards = new ArrayList<>(Arrays.asList(card1, card2));
+        final Quiz quiz = new Quiz(quizCards, Quiz.Mode.LEARN);
+        QuizModelManager expectedModel = new QuizModelManager();
+        expectedModel.init(quiz);
+
+        QuizModel actual = new QuizModelManager();
+        actual.init(QUIZ);
+        actual.getNextCard();
+
+        AnswerCommand answerCommand = new AnswerCommand(answer);
+        expectedModel.getNextCard();
+        QuizCard card = expectedModel.getNextCard();
+        card.isCorrect(answer);
+
+        String expectedMessage = String.format(AnswerCommand.MESSAGE_QUESTION_ANSWER, card.getQuestion(),
+            card.getAnswer());
+
+        assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validReview_success() {
+        final String answer = "Tokyo";
+        final QuizCard card1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
+        final QuizCard card2 = new QuizCard("Hungary", "Budapest");
+        final List<QuizCard> quizCards = new ArrayList<>(Arrays.asList(card1, card2));
+        final Quiz quiz = new Quiz(quizCards, Quiz.Mode.LEARN);
+        QuizModelManager expectedModel = new QuizModelManager();
+        expectedModel.init(quiz);
+
+        QuizModel actual = new QuizModelManager();
+        actual.init(new Quiz(quizCards, Quiz.Mode.LEARN));
+        actual.getNextCard();
+        actual.getNextCard();
+
+        AnswerCommand answerCommand = new AnswerCommand(answer);
+        expectedModel.getNextCard();
+        expectedModel.getNextCard();
+        QuizCard card = expectedModel.getNextCard();
+        card.isCorrect(answer);
+
+        String expectedMessage = String.format(AnswerCommand.MESSAGE_QUESTION, card.getQuestion());
+
+        assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_correctAndWrongAnswer_success() {
+        final String correctAns = "Tokyo";
+        final String wrongAns = "wronganswer";
+        final QuizCard card1 = new QuizCard("Japan", "Tokyo", Arrays.asList("JP", "Asia"));
+        final QuizCard card2 = new QuizCard("Hungary", "Budapest");
+        final List<QuizCard> quizCards = new ArrayList<>(Arrays.asList(card1, card2));
+        final Quiz quiz = new Quiz(quizCards, Quiz.Mode.LEARN);
+
+        // correct
+        QuizModelManager expectedModel = new QuizModelManager();
+        expectedModel.init(quiz);
+
+        QuizModel actual = new QuizModelManager();
+        actual.init(new Quiz(quizCards, Quiz.Mode.LEARN));
+        actual.getNextCard();
+        actual.getNextCard();
+        actual.getNextCard();
+
+        AnswerCommand answerCommand = new AnswerCommand(correctAns);
+        expectedModel.getNextCard();
+        expectedModel.getNextCard();
+        expectedModel.getNextCard();
+        QuizCard card = expectedModel.getNextCard();
+        card.isCorrect(correctAns);
+
+        String expectedMessage = MESSAGE_CORRECT
+            + String.format(AnswerCommand.MESSAGE_QUESTION, card.getQuestion());
+
+        assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
+
+        // wrong
+        answerCommand = new AnswerCommand(wrongAns);
+        actual.getNextCard();
+        card = expectedModel.getNextCard();
+        card.isCorrect(wrongAns);
+
+        expectedMessage = String.format(MESSAGE_WRONG, card.getAnswer())
+            + String.format(MESSAGE_QUESTION, card.getQuestion());
+
+        assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
+
+        // complete the quiz
+        answerCommand = new AnswerCommand("Hungary");
+        actual.getNextCard();
+        card = expectedModel.getNextCard();
+        card.isCorrect(wrongAns);
+        expectedModel.end();
+
+        expectedMessage = MESSAGE_CORRECT + MESSAGE_COMPLETE;
+
+        assertCommandSuccess(answerCommand, actual, commandHistory, expectedMessage, expectedModel);
+
+    }
+
+    @Test
+    public void equals() {
+        AnswerCommand answerCommand = new AnswerCommand("Tokyo");
+        AnswerCommand answerCommandDiff = new AnswerCommand("Something");
+
+        // same object -> returns true
+        assertTrue(answerCommand.equals(answerCommand));
+
+        // same values -> returns true
+        AnswerCommand answerCommandCopy = new AnswerCommand("Tokyo");
+        assertTrue(answerCommand.equals(answerCommandCopy));
+
+        // different answer -> returns false
+        assertFalse(answerCommand.equals(answerCommandDiff));
+
+        // null -> returns false
+        assertFalse(answerCommand == null);
+
+        // differnt type -> returns false
+        assertFalse(answerCommand.equals(5));
+    }
+}

--- a/src/test/java/braintrain/quiz/commands/QuizCommandTestUtil.java
+++ b/src/test/java/braintrain/quiz/commands/QuizCommandTestUtil.java
@@ -1,0 +1,45 @@
+package braintrain.quiz.commands;
+
+import static org.junit.Assert.assertEquals;
+
+import braintrain.logic.CommandHistory;
+import braintrain.logic.commands.CommandResult;
+import braintrain.logic.commands.exceptions.CommandException;
+import braintrain.quiz.QuizModel;
+
+/**
+ * Contains helper methods for testing commands.
+ */
+public class QuizCommandTestUtil {
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
+     * - the {@code actualModel} matches {@code expectedModel} <br>
+     * - the {@code actualCommandHistory} remains unchanged.
+     */
+    public static void assertCommandSuccess(QuizCommand command, QuizModel actualModel,
+                                            CommandHistory actualCommandHistory, CommandResult expectedCommandResult,
+                                            QuizModel expectedModel) {
+        CommandHistory expectedCommandHistory = new CommandHistory(actualCommandHistory);
+        try {
+            CommandResult result = command.execute(actualModel, actualCommandHistory);
+            assertEquals(expectedCommandResult, result);
+            assertEquals(expectedModel, actualModel);
+            assertEquals(expectedCommandHistory, actualCommandHistory);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(QuizCommand, QuizModel, CommandHistory,
+     * CommandResult, QuizModel)}
+     * that takes a string {@code expectedMessage}.
+     */
+    public static void assertCommandSuccess(QuizCommand command, QuizModel actualModel,
+                                            CommandHistory actualCommandHistory,
+                                            String expectedMessage, QuizModel expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        assertCommandSuccess(command, actualModel, actualCommandHistory, expectedCommandResult, expectedModel);
+    }
+}


### PR DESCRIPTION
`Quiz`:
- fixed generate, so `LEARN` mode will be a combination of `PREVIEW` and `REVIEW`
- added equals 

`QuizCard`:
- changed the logic of `isCorrect`, answer will not be case-sensitive but when shown to User it will still be in the correct case form.

`StartCommand`:
- just a skeleton to ensure that the rest is working
- hardcoded values need to be replaced by session and quiz

`QuizModeParser`: 
- an equivalent of BrainTrainParser, except it uses QuizCommand instead
- so it will parse commands and answer in quiz mode

`AnswerCommand`:
- it will process any other input except quiz command as answer
- check if correct and process it